### PR TITLE
QGIS: add results into new group

### DIFF
--- a/bin/qgis/smoderp2d-plugin/smoderp_2D_dockwidget.py
+++ b/bin/qgis/smoderp2d-plugin/smoderp_2D_dockwidget.py
@@ -407,6 +407,7 @@ class Smoderp2DDockWidget(QtWidgets.QDockWidget):
         group = root.insertGroup(0, "SMODERP2D")
 
         outdir = self.main_output_lineEdit.text().strip()
+        first = True
         for map_path in glob.glob(os.path.join(outdir, '*.asc')):
             layer = QgsRasterLayer(
                 map_path, os.path.basename(os.path.splitext(map_path)[0])
@@ -419,8 +420,10 @@ class Smoderp2DDockWidget(QtWidgets.QDockWidget):
             QgsProject.instance().addMapLayer(layer, False)
             node = group.addLayer(layer)
             node.setExpanded(False)
+            node.setItemVisibilityChecked(first is True)
+            first = False
 
-        # QGIUS bug: group must be collapsed and than expanded
+        # QGIS bug: group must be collapsed and than expanded
         group.setExpanded(False)
         group.setExpanded(True)
 

--- a/bin/qgis/smoderp2d-plugin/smoderp_2D_dockwidget.py
+++ b/bin/qgis/smoderp2d-plugin/smoderp_2D_dockwidget.py
@@ -25,13 +25,16 @@
 import os
 import sys
 import tempfile
+import glob
 
 from PyQt5 import QtWidgets, uic
 from PyQt5.QtCore import pyqtSignal, QFileInfo, QSettings, QCoreApplication, Qt
-
+from PyQt5.QtGui import QColor
 from PyQt5.QtWidgets import QFileDialog, QProgressBar, QMenu
+
 from qgis.core import QgsProviderRegistry, QgsMapLayerProxyModel, \
-    QgsVectorLayer, QgsRasterLayer, QgsTask, QgsApplication, Qgis, QgsProject
+    QgsVectorLayer, QgsRasterLayer, QgsTask, QgsApplication, Qgis, QgsProject, \
+    QgsRasterBandStats, QgsSingleBandPseudoColorRenderer, QgsGradientColorRamp
 from qgis.utils import iface
 from qgis.gui import QgsMapLayerComboBox, QgsFieldComboBox, QgsMessageBarItem
 
@@ -75,7 +78,6 @@ class SmoderpTask(QgsTask):
         except ProviderError as e:
             self.error = e
             return False
-        runner.show_results()
 
         # resets
         Globals.reset()
@@ -371,13 +373,9 @@ class Smoderp2DDockWidget(QtWidgets.QDockWidget):
             smoderp_task.progressChanged.connect(
                 lambda a: self.progress_bar.setValue(int(a))
             )
-            smoderp_task.taskCompleted.connect(
-                messageBar.clearWidgets
-            )
+            smoderp_task.taskCompleted.connect(self.computationFinished)
 
             # start the task
-            print('********* tasks **************')
-            print(self.task_manager.tasks())
             self.task_manager.addTask(smoderp_task)
         else:
             self._sendMessage(
@@ -385,6 +383,43 @@ class Smoderp2DDockWidget(QtWidgets.QDockWidget):
                 "Some of mandatory fields are not filled correctly.",
                 "CRITICAL"
             )
+
+    @staticmethod
+    def _layerColorRamp(layer):
+        # get min/max values
+        stats = layer.dataProvider().bandStatistics(1, QgsRasterBandStats.All, layer.extent(), 0)
+
+        # get colour definitions
+        renderer = QgsSingleBandPseudoColorRenderer(layer.dataProvider(), 1)
+        color_ramp = QgsGradientColorRamp(QColor(239, 239, 255), QColor(0,   0, 255))
+        renderer.setClassificationMin(stats.minimumValue)
+        renderer.setClassificationMax(stats.maximumValue)
+        renderer.createShader(color_ramp)
+
+        return renderer
+
+    def computationFinished(self):
+        # clear message bar
+        self.iface.messageBar().clearWidgets
+
+        # show results
+        root = QgsProject.instance().layerTreeRoot()
+        group = root.insertGroup(0, "SMODERP")
+        group.setExpanded(True)
+
+        outdir = self.main_output_lineEdit.text().strip()
+        for map_path in glob.glob(os.path.join(outdir, '*.asc')):
+            layer = QgsRasterLayer(
+                map_path, os.path.basename(os.path.splitext(map_path)[0])
+            )
+
+            # set symbology
+            layer.setRenderer(self._layerColorRamp(layer))
+
+            # add layer into group
+            QgsProject.instance().addMapLayer(layer, False)
+            node = group.addLayer(layer)
+            node.setExpanded(False)
 
     def _getInputParams(self):
         """Get input parameters from QGIS plugin."""

--- a/bin/qgis/smoderp2d-plugin/smoderp_2D_dockwidget.py
+++ b/bin/qgis/smoderp2d-plugin/smoderp_2D_dockwidget.py
@@ -391,7 +391,7 @@ class Smoderp2DDockWidget(QtWidgets.QDockWidget):
 
         # get colour definitions
         renderer = QgsSingleBandPseudoColorRenderer(layer.dataProvider(), 1)
-        color_ramp = QgsGradientColorRamp(QColor(239, 239, 255), QColor(0,   0, 255))
+        color_ramp = QgsGradientColorRamp(QColor(239, 239, 255), QColor(0, 0, 255))
         renderer.setClassificationMin(stats.minimumValue)
         renderer.setClassificationMax(stats.maximumValue)
         renderer.createShader(color_ramp)

--- a/bin/qgis/smoderp2d-plugin/smoderp_2D_dockwidget.py
+++ b/bin/qgis/smoderp2d-plugin/smoderp_2D_dockwidget.py
@@ -404,8 +404,7 @@ class Smoderp2DDockWidget(QtWidgets.QDockWidget):
 
         # show results
         root = QgsProject.instance().layerTreeRoot()
-        group = root.insertGroup(0, "SMODERP")
-        group.setExpanded(True)
+        group = root.insertGroup(0, "SMODERP2D")
 
         outdir = self.main_output_lineEdit.text().strip()
         for map_path in glob.glob(os.path.join(outdir, '*.asc')):
@@ -420,6 +419,10 @@ class Smoderp2DDockWidget(QtWidgets.QDockWidget):
             QgsProject.instance().addMapLayer(layer, False)
             node = group.addLayer(layer)
             node.setExpanded(False)
+
+        # QGIUS bug: group must be collapsed and than expanded
+        group.setExpanded(False)
+        group.setExpanded(True)
 
     def _getInputParams(self):
         """Get input parameters from QGIS plugin."""

--- a/bin/qgis/smoderp2d-plugin/smoderp_2D_dockwidget.py
+++ b/bin/qgis/smoderp2d-plugin/smoderp_2D_dockwidget.py
@@ -423,7 +423,7 @@ class Smoderp2DDockWidget(QtWidgets.QDockWidget):
             node.setItemVisibilityChecked(first is True)
             first = False
 
-        # QGIS bug: group must be collapsed and than expanded
+        # QGIS bug: group must be collapsed and then expanded
         group.setExpanded(False)
         group.setExpanded(True)
 

--- a/smoderp2d/__init__.py
+++ b/smoderp2d/__init__.py
@@ -223,40 +223,6 @@ class QGISRunner(GrassGisRunner):
             except SmoderpError as e:
                 raise SmoderpError('{}'.format(e))
 
-    @staticmethod
-    def color_ramp(layer):
-        from PyQt5.QtGui import QColor
-        from qgis.core import (
-            QgsRasterBandStats, QgsSingleBandPseudoColorRenderer, QgsGradientColorRamp 
-        )
-
-        # get min/max values
-        stats = layer.dataProvider().bandStatistics(1, QgsRasterBandStats.All, layer.extent(), 0)
-
-        # get colour definitions
-        renderer = QgsSingleBandPseudoColorRenderer(layer.dataProvider(), 1)
-        color_ramp = QgsGradientColorRamp(QColor(239, 239, 255), QColor(0,   0, 255))
-        renderer.setClassificationMin(stats.minimumValue)
-        renderer.setClassificationMax(stats.maximumValue)
-        renderer.createShader(color_ramp)
-
-        return renderer
-
-    def show_results(self):
-        import glob
-        from qgis.core import QgsProject, QgsRasterLayer
-
-        for map_path in glob.glob(os.path.join(Globals.outdir, '*.asc')):
-            layer = QgsRasterLayer(
-                map_path, os.path.basename(os.path.splitext(map_path)[0])
-            )
-
-            # set symbology
-            layer.setRenderer(self.color_ramp(layer))
-            layer.triggerRepaint()
-
-            QgsProject.instance().addMapLayer(layer)
-
     def export_data(self):
         pass
 


### PR DESCRIPTION
This PR separates results into a new layer group:

![image](https://github.com/storm-fsv-cvut/smoderp2d/assets/5683186/4d1d32b9-8a31-41e5-a422-269d78ffb340)


Procedure, which adds layers into layer tree, moved from runner (different thread) to QGIS plugin. Intensive communication with layer tree from different thread is causing different problems. It's not good idea to do it. 

See

```
Warning: QObject::setParent: Cannot set parent, new parent is in a different thread
Warning: QObject::setParent: Cannot set parent, new parent is in a different thread
Warning: QObject::setParent: Cannot set parent, new parent is in a different thread
Warning: QObject::setParent: Cannot set parent, new parent is in a different thread
Warning: QObject::setParent: Cannot set parent, new parent is in a different thread
```