### PR TITLE
Produce temporary data only if enabled

### DIFF
--- a/smoderp2d/providers/arcgis/__init__.py
+++ b/smoderp2d/providers/arcgis/__init__.py
@@ -1,5 +1,7 @@
 import os
 import logging
+import shutil
+
 import numpy.ma as ma
 
 from smoderp2d.core.general import Globals, GridGlobals


### PR DESCRIPTION
In https://github.com/storm-fsv-cvut/smoderp2d/commit/2d741cf3f8d6c83d8379cd5987851a33cee13494 has been added option "Generate also temporary data". But temporary data are generated by default. This PR fixes this issue by deleting temporary data when the option "Generate also temporary data" is unchecked.