### PR TITLE
Do not fail on broken historical items

### DIFF
--- a/bin/qgis/smoderp2d-plugin/smoderp_2D_dockwidget.py
+++ b/bin/qgis/smoderp2d-plugin/smoderp_2D_dockwidget.py
@@ -504,8 +504,14 @@ class Smoderp2DDockWidget(QtWidgets.QDockWidget):
         :param run: The current run info in format (timestamp, params, maps)
         """
         this_run = HistoryWidget(f'{run[1]["output"]} -- {run[0]}')
-        this_run.saveHistory(run[1], run[2])
-        self.history_tab.insertItem(0, this_run)
+        try:
+            this_run.saveHistory(run[1], run[2])
+            self.history_tab.insertItem(0, this_run)
+        except (KeyError, IndexError) as e:
+            iface.messageBar().pushMessage(
+                f'Failed to add historical item {run[0]}: ', str(e),
+                level=Qgis.Warning
+            )
         self.history_tab.itemDoubleClicked.connect(
             self._loadHistoricalParameters
         )


### PR DESCRIPTION
Currently QGIS plugin does not start when historical items are somehow broken:

```
              File "/home/martin/git/storm-fsv-cvut/smoderp2d/bin/qgis/smoderp2d-plugin/smoderp_2D.py", line 210, in run
              self.dockwidget = Smoderp2DDockWidget()
              ^^^^^^^^^^^^^^^^^^^^^
              File "/home/martin/git/storm-fsv-cvut/smoderp2d/bin/qgis/smoderp2d-plugin/smoderp_2D_dockwidget.py", line 171, in __init__
              self.retranslateUi()
              File "/home/martin/git/storm-fsv-cvut/smoderp2d/bin/qgis/smoderp2d-plugin/smoderp_2D_dockwidget.py", line 236, in retranslateUi
              self._loadHistory()
              File "/home/martin/git/storm-fsv-cvut/smoderp2d/bin/qgis/smoderp2d-plugin/smoderp_2D_dockwidget.py", line 479, in _loadHistory
              self._addHistoryItem(run)
              File "/home/martin/git/storm-fsv-cvut/smoderp2d/bin/qgis/smoderp2d-plugin/smoderp_2D_dockwidget.py", line 507, in _addHistoryItem
              this_run.saveHistory(run[1], run[2])
              File "/home/martin/git/storm-fsv-cvut/smoderp2d/bin/qgis/smoderp2d-plugin/custom_widgets.py", line 31, in saveHistory
              'elevation': map_names['elevation'][0],
              ~~~~~~~~~~~~~~~~~~~~~~^^^
             IndexError: list index out of range
```

This PR fixes this issue:

![image](https://github.com/storm-fsv-cvut/smoderp2d/assets/5683186/0ce667b1-cedb-4f94-b6b4-dea540e2ae7f)
