### PR TITLE
Save dpre.save on dpre

### DIFF
--- a/smoderp2d/providers/arcgis/__init__.py
+++ b/smoderp2d/providers/arcgis/__init__.py
@@ -77,9 +77,6 @@ class ArcGisProvider(BaseProvider):
     def __init__(self, log_handler=ArcPyLogHandler):
         super(ArcGisProvider, self).__init__()
 
-        # type of computation (default)
-        self.args.workflow_mode = WorkflowMode.full
-
         # options must be defined by set_options()
         self._options = None
 

--- a/smoderp2d/providers/base/__init__.py
+++ b/smoderp2d/providers/base/__init__.py
@@ -197,8 +197,7 @@ class BaseProvider(object):
             # avoid duplicated handlers (e.g. in case of ArcGIS)
             Logger.addHandler(handler)
 
-    @staticmethod
-    def __load_hidden_config():
+    def __load_hidden_config(self):
         """Load hidden configuration with advanced settings.
 
         return ConfigParser: object
@@ -217,6 +216,11 @@ class BaseProvider(object):
         # set logging level
         Logger.setLevel(config.get('logging', 'level', fallback=logging.INFO))
 
+        # set workflow mode
+        self.workflow_mode = WorkflowMode()[config.get(
+            'processes', 'workflow_mode', fallback="full"
+        )]
+
         return config
 
     def _load_data_from_hidden_config(self, ignore=()):
@@ -233,9 +237,6 @@ class BaseProvider(object):
         data['extraout'] = self._hidden_config.getboolean(
             'output', 'extraout', fallback=False
         )
-        self.args.workflow_mode = WorkflowMode()[self._hidden_config.get(
-            'processes', 'workflow_mode', fallback="full"
-        )]
 
         return data
 
@@ -350,6 +351,9 @@ class BaseProvider(object):
                           'pixel_area', 'r', 'rc', 'rr', 'xllcorner',
                           'yllcorner'):
                     data[k] = getattr(GridGlobals, k)
+                self.args.data_file = os.path.join(
+                    Globals.outdir, "dpre.save"
+                )
                 self.save_data(data, self.args.data_file)
                 return
 

--- a/smoderp2d/providers/base/__init__.py
+++ b/smoderp2d/providers/base/__init__.py
@@ -217,7 +217,7 @@ class BaseProvider(object):
         Logger.setLevel(config.get('logging', 'level', fallback=logging.INFO))
 
         # set workflow mode
-        self.workflow_mode = WorkflowMode()[config.get(
+        self.args.workflow_mode = WorkflowMode()[config.get(
             'processes', 'workflow_mode', fallback="full"
         )]
 

--- a/smoderp2d/providers/grass/__init__.py
+++ b/smoderp2d/providers/grass/__init__.py
@@ -98,9 +98,6 @@ class GrassGisProvider(BaseProvider):
     def __init__(self, log_handler=GrassGisLogHandler):
         super(GrassGisProvider, self).__init__()
 
-        # type of computation (default)
-        self.args.workflow_mode = WorkflowMode.full
-
         # options must be defined by set_options()
         self._options = None
 


### PR DESCRIPTION
Currently `dpre.save` is not saved on `workflow: dpre`. How to test:

Change `.config.ini`:

```diff
-workflow_mode: full
+workflow_mode: dpre
```

Run:

```
./tests/run_grass_gistest.sh rain_sim 001
```

Enter GRASS location:

```
grass /tmp/smoderp2d-rain_sim/test
```

and run:

```
PYTHONPATH=$PYTHONPATH:`pwd` ./bin/grass/r.smoderp2d/r.smoderp2d.py \
    elevation=dem@PERMANENT \
    soil=soils@PERMANENT \
    soil_type_fieldname=Soil \
    vegetation=landuse@PERMANENT \
    vegetation_type_fieldname=LandUse \
    rainfall_file=tests/data/rainfall_nucice.txt \
    maxdt=5 end_time=5 \
    points=points@PERMANENT points_fieldname='point_id' \
    table_soil_vegetation=soil_veg_tab@PERMANENT \
    table_soil_vegetation_fieldname=soilveg \
    streams=streams@PERMANENT \
    channel_properties_table=streams_shape@PERMANENT \
    streams_channel_type_fieldname=channel_id \
    output=tests/data/output
```

Check existence of `dpre.save`:

```
file tests/data/output/dpre.save
```

