### PR TITLE
write mat arrays to temp

### DIFF
--- a/smoderp2d/providers/base/data_preparation.py
+++ b/smoderp2d/providers/base/data_preparation.py
@@ -661,7 +661,7 @@ class PrepareDataGISBase(PrepareDataBase):
 
         # write mat arrays to temp
         for k, v in self.data.items():
-            if k not in ('array_points', 'sr') and isinstance(v, np.ndarray):
+            if isinstance(v, np.ndarray) and k not in ('array_points', 'sr'):
                 self.storage.write_raster(
                     v, k, 'temp'
                 )

--- a/smoderp2d/providers/base/data_preparation.py
+++ b/smoderp2d/providers/base/data_preparation.py
@@ -655,13 +655,16 @@ class PrepareDataGISBase(PrepareDataBase):
             GridGlobals.r, GridGlobals.c, GridGlobals.NoDataValue,
             self.data['mat_nan']
         )
-        self.storage.write_raster(
-            self.data['mat_boundary'], 'mat_boundary', 'temp'
-        )
-
         GridGlobals.rr, GridGlobals.rc = self._get_rr_rc(
             GridGlobals.r, GridGlobals.c, self.data['mat_boundary']
         )
+
+        # write mat arrays to temp
+        for k, v in self.data.items():
+            if k not in ('array_points', 'sr') and isinstance(v, np.ndarray):
+                self.storage.write_raster(
+                    v, k, 'temp'
+                )
 
         self.data['mat_boundary'] = None  # ML: -> JJ ???
 

--- a/smoderp2d/providers/base/data_preparation.py
+++ b/smoderp2d/providers/base/data_preparation.py
@@ -659,12 +659,13 @@ class PrepareDataGISBase(PrepareDataBase):
             GridGlobals.r, GridGlobals.c, self.data['mat_boundary']
         )
 
-        # write mat arrays to temp
-        for k, v in self.data.items():
-            if isinstance(v, np.ndarray) and k not in ('array_points', 'sr'):
-                self.storage.write_raster(
-                    v, k, 'temp'
-                )
+        if self._input_params['generate_temporary']:
+            # write mat arrays to temp
+            for k, v in self.data.items():
+                if isinstance(v, np.ndarray) and k not in ('array_points', 'sr'):
+                    self.storage.write_raster(
+                        v, k, 'temp'
+                    )
 
         self.data['mat_boundary'] = None  # ML: -> JJ ???
 


### PR DESCRIPTION
This PR writes `mat` arrays to `temp` directory:

![image](https://github.com/storm-fsv-cvut/smoderp2d/assets/5683186/0db74ce0-fee9-42db-9292-fcc15e904447)
