### PR TITLE
ArcGIS: rasterize soilveg (all touched pixels)

### DIFF
--- a/smoderp2d/providers/arcgis/data_preparation.py
+++ b/smoderp2d/providers/arcgis/data_preparation.py
@@ -290,8 +290,7 @@ class PrepareData(PrepareDataGISBase):
             aoi_mask = self.storage.output_filepath('aoi_mask')
             with arcpy.EnvManager(nodata=GridGlobals.NoDataValue, cellSize=aoi_mask, cellAlignment=aoi_mask, snapRaster=aoi_mask):
                 arcpy.conversion.PolygonToRaster(
-                    soilveg_aoi_path, field, output, "MAXIMUM_AREA", "",
-                    GridGlobals.dy
+                    soilveg_aoi_path, field, output, cellsize=GridGlobals.dy
                 )
             self.soilveg_fields[field] = self._rst2np(output)
             self._check_soilveg_dim(field)


### PR DESCRIPTION
Issue #387 seems to be related only to ArcGIS.

Output from master in QGIS: 

![image](https://github.com/storm-fsv-cvut/smoderp2d/assets/5683186/9109232f-243e-4d7f-b79f-545fa9f4bdd0)

This PR changes `PolygonToRaster` to use default `cell_assignment`. After this change the pixels on edges should be filled by a value:

![image](https://github.com/storm-fsv-cvut/smoderp2d/assets/5683186/5badd34f-8d65-4b78-ba96-504e19b0571b)
