### PR TITLE
GH actions: update Ubuntu version for GRASS tests - 22.04 -> 24.04

### DIFF
--- a/.github/workflows/grass_provider.yml
+++ b/.github/workflows/grass_provider.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container:
       image: osgeo/grass-gis:releasebranch_8_3-debian
 
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container:
       image: osgeo/grass-gis:releasebranch_8_3-debian
 


### PR DESCRIPTION
GRASS tests were ignored in 8c1f4925c11d6004bfe3aa2e401e7ee7316b490c